### PR TITLE
[DAT-671] - Include 2 decimals in amount and discounts

### DIFF
--- a/Doppler.AccountPlans.Test/CalculateUpgradeCostTest.cs
+++ b/Doppler.AccountPlans.Test/CalculateUpgradeCostTest.cs
@@ -59,7 +59,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(14, result.Total);
+            Assert.Equal(14.25m, result.Total);
             Assert.Equal(0, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -86,7 +86,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(25, result.Total);
+            Assert.Equal(25.5m, result.Total);
             Assert.Equal(0, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -237,7 +237,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(12, result.Total);
+            Assert.Equal(12.25m, result.Total);
             Assert.Equal(2, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -268,7 +268,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(23, result.Total);
+            Assert.Equal(23.5m, result.Total);
             Assert.Equal(2, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -330,7 +330,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(12, result.Total);
+            Assert.Equal(12.25m, result.Total);
             Assert.Equal(2, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -361,7 +361,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(12, result.Total);
+            Assert.Equal(12.25m, result.Total);
             Assert.Equal(2, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -391,7 +391,7 @@ namespace Doppler.AccountPlans
 
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
             // Assert
-            Assert.Equal(15, result.Total);
+            Assert.Equal(15.5m, result.Total);
             Assert.Equal(10, result.DiscountPaymentAlreadyPaid);
         }
 
@@ -422,7 +422,7 @@ namespace Doppler.AccountPlans
             var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
 
             // Assert
-            Assert.Equal(17, result.Total);
+            Assert.Equal(17.5m, result.Total);
             Assert.Equal(8, result.DiscountPaymentAlreadyPaid);
         }
 

--- a/Doppler.AccountPlans/Utils/CalculateUpgradeCostHelper.cs
+++ b/Doppler.AccountPlans/Utils/CalculateUpgradeCostHelper.cs
@@ -43,10 +43,10 @@ namespace Doppler.AccountPlans.Utils
 
             var result = new PlanAmountDetails
             {
-                DiscountPaymentAlreadyPaid = Math.Round(currentPlan.Fee * numberOfMonthsToDiscount, MidpointRounding.AwayFromZero),
+                DiscountPaymentAlreadyPaid = Math.Round(currentPlan.Fee * numberOfMonthsToDiscount, 2),
                 DiscountPrepayment = new DiscountPrepayment
                 {
-                    Amount = Math.Round((newPlan.Fee * newDiscount.MonthPlan * newDiscount.DiscountPlanFee) / 100, MidpointRounding.AwayFromZero),
+                    Amount = Math.Round((newPlan.Fee * newDiscount.MonthPlan * newDiscount.DiscountPlanFee) / 100, 2),
                     DiscountPercentage = newDiscount.DiscountPlanFee
                 }
             };


### PR DESCRIPTION
Include 2 decimals in amount and discounts.

Reponse:

![image](https://user-images.githubusercontent.com/70591946/139926762-5bc63914-663e-47a3-b830-2fbf24903739.png)


Task: [DAT-671](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-671)