### PR TITLE
feat: [DAT-697] Add Get promocode endpoint

### DIFF
--- a/Doppler.AccountPlans.Test/GetPromoCodeTest.cs
+++ b/Doppler.AccountPlans.Test/GetPromoCodeTest.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Doppler.AccountPlans.Encryption;
+using Doppler.AccountPlans.Infrastructure;
+using Doppler.AccountPlans.Model;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Doppler.AccountPlans
+{
+    public class GetPromoCodeTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private const string TokenAccount123Test1AtTestDotComExpire20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJpYXQiOjE1ODQ0NjM1MjksImV4cCI6MTY0NTU2NzUyOX0.eJZYYKZOw439rWO98urRkmR4H9UqhVoD870RECWtOQlsUEpTeNPFgQfz-bQHyYZ73lkNunvmW4s31wJB1BFrVr4JqklhvM0zEem70aGDrxa1WwNB268p-dzGZqG_RAU4k7oW1JwSvrg6DGVQTlP2DyeNvyO1qwpt8m0yS4z6x3jTzn4V-6iEOIBMp2DxwzMU6x03e_I4jZJRal2T9941BoM88c2S-IXWR_uS0AGbH1Yl7ZMUSx7wQEZi2o7UpOefR6TpKkOTj5iSeSMSVvpGvOjKP5Lk_Y7TSLpNEKTcMaahA1DK4R_EYAbtiIWIvSscEqxlWBzo7AB1MQdNbqrVlA";
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public GetPromoCodeTest(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task GET_PromoCode_Information_should_get_right_values_when_promoCode_is_valid()
+        {
+            // Arrange
+            const string expectedContent = "{\"extraCredits\":1,\"discountPercentage\":2}";
+            var promoCodeRepositoryMock = new Mock<IPromotionRepository>();
+            promoCodeRepositoryMock.Setup(x => x.GetPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(new Promotion
+                {
+                    ExtraCredits = 1,
+                    DiscountPercentage = 2
+                });
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(promoCodeRepositoryMock.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/plans/1/validate/test")
+            {
+                Headers =
+                {
+                    {
+                        "Authorization", $"Bearer {TokenAccount123Test1AtTestDotComExpire20330518}"
+                    }
+                }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedContent, responseContent);
+        }
+
+        [Fact]
+        public async Task GET_PromoCode_Information_should_return_not_found_when_promoCode_not_exist()
+        {
+            // Arrange
+            var promoCodeRepositoryMock = new Mock<IPromotionRepository>();
+            promoCodeRepositoryMock.Setup(x => x.GetPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(null as Promotion);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(promoCodeRepositoryMock.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/plans/1/validate/test")
+            {
+                Headers =
+                {
+                    {
+                        "Authorization", $"Bearer {TokenAccount123Test1AtTestDotComExpire20330518}"
+                    }
+                }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+}

--- a/Doppler.AccountPlans/Encryption/EncryptionService.cs
+++ b/Doppler.AccountPlans/Encryption/EncryptionService.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Doppler.AccountPlans.Encryption
+{
+    //NOTE: This service was copied from https://github.com/MakingSense/doppler-forms/tree/master/DopplerForms.Services/Encryption
+    public class EncryptionService : IEncryptionService, IDisposable
+    {
+        private readonly IOptions<EncryptionSettings> _options;
+        private bool _initialized;
+        private RijndaelManaged _symmetricKey;
+        private Lazy<ICryptoTransform> _encryptor;
+        private Lazy<ICryptoTransform> _decryptor;
+
+        public EncryptionService(IOptions<EncryptionSettings> options)
+        {
+            _options = options;
+        }
+
+        public string DecryptAES256(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            EnsureInitialization();
+
+            var cipherTextBytes = Convert.FromBase64String(input);
+
+            using var memoryStream = new MemoryStream(cipherTextBytes);
+            using var cryptoStream = new CryptoStream(memoryStream, _decryptor.Value, CryptoStreamMode.Read);
+            var plainTextBytes = new byte[cipherTextBytes.Length];
+            var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
+            return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
+        }
+
+        public string EncryptAES256(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            EnsureInitialization();
+
+            var plainTextBytes = Encoding.UTF8.GetBytes(input);
+
+            using var memoryStream = new MemoryStream();
+            using var cryptoStream = new CryptoStream(memoryStream, _encryptor.Value, CryptoStreamMode.Write);
+            cryptoStream.Write(plainTextBytes, 0, plainTextBytes.Length);
+            cryptoStream.FlushFinalBlock();
+            return Convert.ToBase64String(memoryStream.ToArray());
+        }
+
+        private void EnsureInitialization()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            var initVectorBytes = Encoding.ASCII.GetBytes(_options.Value.InitVectorAsAsciiString);
+            var password = new PasswordDeriveBytes(
+                _options.Value.Password,
+                Encoding.ASCII.GetBytes(_options.Value.SaltValueAsAsciiString),
+                "SHA1",
+                5);
+
+            var keyBytes = password.GetBytes(32); // KeySize = 256 bits = 32 bytes
+
+            _symmetricKey = new RijndaelManaged() { Mode = CipherMode.CBC };
+            _encryptor = new Lazy<ICryptoTransform>(() => _symmetricKey.CreateEncryptor(keyBytes, initVectorBytes));
+            _decryptor = new Lazy<ICryptoTransform>(() => _symmetricKey.CreateDecryptor(keyBytes, initVectorBytes));
+            _initialized = true;
+        }
+
+        public void Dispose()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            if (_decryptor.IsValueCreated)
+            {
+                _decryptor.Value.Dispose();
+            }
+
+            if (_encryptor.IsValueCreated)
+            {
+                _encryptor.Value.Dispose();
+            }
+        }
+    }
+}

--- a/Doppler.AccountPlans/Encryption/EncryptionSettings.cs
+++ b/Doppler.AccountPlans/Encryption/EncryptionSettings.cs
@@ -1,0 +1,9 @@
+namespace Doppler.AccountPlans.Encryption
+{
+    public class EncryptionSettings
+    {
+        public string InitVectorAsAsciiString { get; set; }
+        public string SaltValueAsAsciiString { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Doppler.AccountPlans/Encryption/IEncryptionService.cs
+++ b/Doppler.AccountPlans/Encryption/IEncryptionService.cs
@@ -1,0 +1,9 @@
+namespace Doppler.AccountPlans.Encryption
+{
+    public interface IEncryptionService
+    {
+        public string DecryptAES256(string input);
+        void Dispose();
+        public string EncryptAES256(string input);
+    }
+}

--- a/Doppler.AccountPlans/Infrastructure/IPromotionRepository.cs
+++ b/Doppler.AccountPlans/Infrastructure/IPromotionRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Doppler.AccountPlans.Model;
+
+namespace Doppler.AccountPlans.Infrastructure
+{
+    public interface IPromotionRepository
+    {
+        Task<Promotion> GetPromotionByCode(string code, int planId);
+    }
+}

--- a/Doppler.AccountPlans/Infrastructure/PromotionRepository.cs
+++ b/Doppler.AccountPlans/Infrastructure/PromotionRepository.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using Dapper;
+using Doppler.AccountPlans.Enums;
+using Doppler.AccountPlans.Model;
+
+namespace Doppler.AccountPlans.Infrastructure
+{
+    public class PromotionRepository : IPromotionRepository
+    {
+        private readonly IDatabaseConnectionFactory _connectionFactory;
+
+        public PromotionRepository(IDatabaseConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
+
+        public async Task<Promotion> GetPromotionByCode(string code, int planId)
+        {
+            using var connection = await _connectionFactory.GetConnection();
+
+            var userType = await GetUserTypeByPlan(planId);
+
+            var promotion = await connection.QueryFirstOrDefaultAsync<Promotion>(@"
+SELECT
+    [IdPromotion],
+    [IdUserTypePlan],
+    [CreationDate],
+    [ExpiringDate],
+    [TimesUsed],
+    [TimesToUse],
+    [Code],
+    [ExtraCredits],
+    [Active],
+    [DiscountPlanFee] as DiscountPercentage,
+    [AllPlans],
+    [AllSubscriberPlans],
+    [AllPrepaidPlans],
+    [AllMonthlyPlans],
+    [Duration]
+FROM
+    [Promotions]
+WHERE
+    [Code] = @code AND
+    [Active] = 1 AND
+    ([TimesToUse] is null OR [TimesToUse] > [TimesUsed]) AND
+    ([ExpiringDate] is null OR [ExpiringDate] >= @now) AND
+    ([IdUserTypePlan] = @planId OR
+    [AllPlans] = 1 OR
+    (@userType = @individual AND [AllPrepaidPlans] = 1) OR
+    (@userType = @subscribers AND [AllSubscriberPlans] = 1) OR
+    (@userType = @monthly AND [AllMonthlyPlans] = 1))",
+                new
+                {
+                    code,
+                    planId,
+                    userType,
+                    @individual = (int)UserTypesEnum.Individual,
+                    @subscribers = (int)UserTypesEnum.Subscribers,
+                    @monthly = (int)UserTypesEnum.Monthly,
+                    @now = DateTime.Now
+                });
+
+            return promotion;
+        }
+
+        private async Task<int> GetUserTypeByPlan(int planId)
+        {
+            using var connection = await _connectionFactory.GetConnection();
+
+            var userPlanTypeId = await connection.QueryFirstOrDefaultAsync<int>(@"
+SELECT
+    [IdUserType]
+FROM
+    [UserTypesPlans]
+WHERE
+    [IdUserTypePlan] = @planId", new
+            {
+                planId
+            });
+
+            return userPlanTypeId;
+        }
+    }
+}

--- a/Doppler.AccountPlans/Model/Promotion.cs
+++ b/Doppler.AccountPlans/Model/Promotion.cs
@@ -1,0 +1,8 @@
+namespace Doppler.AccountPlans.Model
+{
+    public class Promotion
+    {
+        public int? ExtraCredits { get; set; }
+        public int? DiscountPercentage { get; set; }
+    }
+}

--- a/Doppler.AccountPlans/Startup.cs
+++ b/Doppler.AccountPlans/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using Doppler.AccountPlans.Encryption;
 using Doppler.AccountPlans.Infrastructure;
 using Doppler.AccountPlans.Utils;
 using Microsoft.AspNetCore.Builder;
@@ -30,6 +31,9 @@ namespace Doppler.AccountPlans
             services.AddSingleton<Weather.WeatherForecastService>();
             services.AddSingleton<Weather.DataService>();
             services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
+            services.AddScoped<IEncryptionService, EncryptionService>();
+            services.Configure<EncryptionSettings>(Configuration.GetSection(nameof(EncryptionSettings)));
+            services.AddScoped<IPromotionRepository, PromotionRepository>();
 
             services.AddSwaggerGen(c =>
             {


### PR DESCRIPTION
# Background
We need to create a new Get Promocode endpoint to know if a valid or not
contract:
`GET /plans/{planId}/validate/{promocode}`
return
```
{
    "extraCredits": null,
    "discountPlanFee": 2
}
```