### PR TITLE
feat: [DAT-697] Add promocode in calculate cost helper

### DIFF
--- a/Doppler.AccountPlans.Test/AuthorizationTest.cs
+++ b/Doppler.AccountPlans.Test/AuthorizationTest.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Doppler.AccountPlans.Encryption;
 using Doppler.AccountPlans.Infrastructure;
 using Doppler.AccountPlans.Model;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -129,12 +130,20 @@ namespace Doppler.AccountPlans
                 {
                     Fee = 1
                 });
+            var promotionRepositoryMock = new Mock<IPromotionRepository>();
+            promotionRepositoryMock.Setup(x => x.GetPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(new Promotion
+                {
+                    DiscountPercentage = 0
+                });
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton(accountPlanRepositoryMock.Object);
+                    services.AddSingleton(promotionRepositoryMock.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 

--- a/Doppler.AccountPlans.Test/CalculateUpgradeCostTest.cs
+++ b/Doppler.AccountPlans.Test/CalculateUpgradeCostTest.cs
@@ -28,7 +28,7 @@ namespace Doppler.AccountPlans
                 Fee = 5,
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(5, result.Total);
@@ -53,7 +53,7 @@ namespace Doppler.AccountPlans
                 Fee = 5,
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(14.25m, result.Total);
@@ -78,7 +78,7 @@ namespace Doppler.AccountPlans
                 Fee = 5,
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(25.5m, result.Total);
@@ -103,7 +103,7 @@ namespace Doppler.AccountPlans
                 Fee = 5,
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, null, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(45, result.Total);
@@ -134,7 +134,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 0
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(3, result.Total);
@@ -165,7 +165,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 0
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(5, result.Total);
@@ -196,7 +196,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 0
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(5, result.Total);
@@ -227,7 +227,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 0
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(12.25m, result.Total);
@@ -258,7 +258,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 0
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(23.5m, result.Total);
@@ -289,7 +289,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 0
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(43, result.Total);
@@ -320,7 +320,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 1
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(12.25m, result.Total);
@@ -351,7 +351,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 1
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(12.25m, result.Total);
@@ -382,7 +382,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 2
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
             // Assert
             Assert.Equal(15.5m, result.Total);
             Assert.Equal(10, result.DiscountPaymentAlreadyPaid);
@@ -412,7 +412,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 2
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(17.5m, result.Total);
@@ -443,7 +443,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 4
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(27, result.Total);
@@ -474,7 +474,7 @@ namespace Doppler.AccountPlans
                 CurrentMonthPlan = 4
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, currentDiscountPlan, currentPlan, dateTimeProviderMock.Object.Now, null);
 
             // Assert
             Assert.Equal(29, result.Total);
@@ -501,7 +501,7 @@ namespace Doppler.AccountPlans
                 IdUserType = UserTypesEnum.Individual
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, null, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, null, currentPlan, dateTimeProviderMock.Object.Now, new Promotion());
 
             // Assert
             Assert.Equal(5, result.Total);
@@ -509,7 +509,7 @@ namespace Doppler.AccountPlans
         }
 
         [Fact]
-        public void CalculateUpgradeCostHelper_Prepaid_method_should_return_correct_value_when_newPlan_is_montly()
+        public void CalculateUpgradeCostHelper_Prepaid_method_should_return_correct_value_when_newPlan_is_monthly()
         {
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.Now)
@@ -527,11 +527,55 @@ namespace Doppler.AccountPlans
                 IdUserType = UserTypesEnum.Individual
             };
 
-            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, null, currentPlan, dateTimeProviderMock.Object.Now);
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, null, currentPlan, dateTimeProviderMock.Object.Now, new Promotion());
 
             // Assert
             Assert.Equal(15, result.Total);
             Assert.Equal(0, result.DiscountPaymentAlreadyPaid);
+        }
+
+        [Theory]
+        [InlineData(14.55, 3, 0.45, 15)]
+        [InlineData(13.5, 10, 1.5, 15)]
+        [InlineData(500, 50, 500, 1000)]
+        [InlineData(990, 1, 10, 1000)]
+        [InlineData(1000, 0, 0, 1000)]
+        public void CalculateUpgradeCostHelper_Prepaid_promocode_should_return_correct_value_when_newPlan_has_discount_percentage(
+            decimal total,
+            int discountPercentage,
+            decimal discountPromocode,
+            int planFee)
+        {
+            var dateTimeProviderMock = new Mock<IDateTimeProvider>();
+            dateTimeProviderMock.Setup(x => x.Now)
+                .Returns(new DateTime(2021, 9, 22));
+
+            var newPlan = new PlanInformation
+            {
+                Fee = planFee,
+                IdUserType = UserTypesEnum.Monthly
+            };
+
+            var currentPlan = new PlanInformation
+            {
+                Fee = 2,
+                IdUserType = UserTypesEnum.Individual
+            };
+
+            var promotion = new Promotion
+            {
+                DiscountPercentage = discountPercentage
+            };
+
+            var result = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, null, currentPlan, dateTimeProviderMock.Object.Now, promotion);
+
+            // Assert
+            Assert.Equal(total, result.Total);
+            Assert.Equal(0, result.DiscountPaymentAlreadyPaid);
+            Assert.Equal(0, result.DiscountPrepayment.Amount);
+            Assert.Equal(0, result.DiscountPrepayment.DiscountPercentage);
+            Assert.Equal(discountPercentage, result.DiscountPromocode.DiscountPercentage);
+            Assert.Equal(discountPromocode, result.DiscountPromocode.Amount);
         }
     }
 }

--- a/Doppler.AccountPlans.Test/GetCalculateUpgradeCostTestTest.cs
+++ b/Doppler.AccountPlans.Test/GetCalculateUpgradeCostTestTest.cs
@@ -4,11 +4,14 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Dapper;
+using Doppler.AccountPlans.Encryption;
 using Doppler.AccountPlans.Enums;
+using Doppler.AccountPlans.Infrastructure;
 using Doppler.AccountPlans.Model;
 using Doppler.AccountPlans.Test.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.Dapper;
 using Xunit;
@@ -54,6 +57,8 @@ namespace Doppler.AccountPlans
                 builder.ConfigureTestServices(services =>
                 {
                     services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(Mock.Of<IPromotionRepository>());
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
@@ -102,6 +107,8 @@ namespace Doppler.AccountPlans
                 builder.ConfigureTestServices(services =>
                 {
                     services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(Mock.Of<IPromotionRepository>());
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 

--- a/Doppler.AccountPlans/Controllers/AccountPlansController.cs
+++ b/Doppler.AccountPlans/Controllers/AccountPlansController.cs
@@ -63,7 +63,6 @@ namespace Doppler.AccountPlans.Controllers
             return new OkObjectResult(upgradeCost);
         }
 
-        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
         [HttpGet("/plans/{planId}/validate/{promocode}")]
         public async Task<IActionResult> GetPromocodeInformation([FromRoute] int planId, [FromRoute] string promocode)
         {

--- a/Doppler.AccountPlans/Controllers/AccountPlansController.cs
+++ b/Doppler.AccountPlans/Controllers/AccountPlansController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using Doppler.AccountPlans.Encryption;
+using Doppler.AccountPlans.Model;
 using Doppler.AccountPlans.Utils;
 
 namespace Doppler.AccountPlans.Controllers
@@ -35,7 +36,11 @@ namespace Doppler.AccountPlans.Controllers
 
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
         [HttpGet("/accounts/{accountName}/newplan/{newPlanId}/calculate")]
-        public async Task<IActionResult> GetCalculateUpgradeCost([FromRoute] string accountName, [FromRoute] int newPlanId, [FromQuery] int discountId, [FromQuery] string promocode = null)
+        public async Task<IActionResult> GetCalculateUpgradeCost(
+            [FromRoute] string accountName,
+            [FromRoute] int newPlanId,
+            [FromQuery] int discountId,
+            [FromQuery] string promocode = null)
         {
             _logger.LogInformation("Calculating plan amount details.");
 
@@ -46,7 +51,15 @@ namespace Doppler.AccountPlans.Controllers
             if (newPlan == null)
                 return new NotFoundResult();
 
-            var upgradeCost = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, discountPlan, currentPlan, _dateTimeProvider.Now);
+            var promotion = new Promotion();
+            if (!string.IsNullOrEmpty(promocode))
+            {
+                var encryptedCode = _encryptionService.EncryptAES256(promocode);
+                promotion = await _promotionRepository.GetPromotionByCode(encryptedCode, newPlanId);
+            }
+
+            var upgradeCost = CalculateUpgradeCostHelper.CalculatePlanAmountDetails(newPlan, discountPlan, currentPlan, _dateTimeProvider.Now, promotion);
+
             return new OkObjectResult(upgradeCost);
         }
 

--- a/Doppler.AccountPlans/Infrastructure/AccountPlansRepository.cs
+++ b/Doppler.AccountPlans/Infrastructure/AccountPlansRepository.cs
@@ -83,7 +83,8 @@ WHERE
             var discountPlan = await connection.QueryFirstOrDefaultAsync<PlanDiscountInformation>(@"
 SELECT
     d.[MonthPlan],
-    d.[DiscountPlanFee]
+    d.[DiscountPlanFee],
+    d.[ApplyPromo]
 FROM
     DiscountXPlan d
 WHERE

--- a/Doppler.AccountPlans/Model/DiscountPromocode.cs
+++ b/Doppler.AccountPlans/Model/DiscountPromocode.cs
@@ -1,0 +1,8 @@
+namespace Doppler.AccountPlans.Model
+{
+    public class DiscountPromocode
+    {
+        public decimal Amount { get; set; }
+        public decimal DiscountPercentage { get; set; }
+    }
+}

--- a/Doppler.AccountPlans/Model/PlanAmountDetails.cs
+++ b/Doppler.AccountPlans/Model/PlanAmountDetails.cs
@@ -5,5 +5,6 @@ namespace Doppler.AccountPlans.Model
         public decimal DiscountPaymentAlreadyPaid { get; set; }
         public DiscountPrepayment DiscountPrepayment { get; set; }
         public decimal Total { get; set; }
+        public DiscountPromocode DiscountPromocode { get; set; }
     }
 }


### PR DESCRIPTION
# Background
We add promo code value to calculate the total of an upgrade
example:
`GET /accounts/{accountname}/newplan/{planId}/calculate?discountId={discountId}&promocode={promocode}`
```
{
    "discountPaymentAlreadyPaid": 0,
    "discountPrepayment": {
        "amount": 0,
        "discountPercentage": 0
    },
    "total": 7.84,
    "discountPromocode": {
        "amount": 0.16,
        "discountPercentage": 2
    }
}
```