### PR TITLE
feat: [DAT-702] Add promocodeId in promotion model

### DIFF
--- a/Doppler.AccountPlans.Test/GetPromoCodeTest.cs
+++ b/Doppler.AccountPlans.Test/GetPromoCodeTest.cs
@@ -26,13 +26,14 @@ namespace Doppler.AccountPlans
         public async Task GET_PromoCode_Information_should_get_right_values_when_promoCode_is_valid()
         {
             // Arrange
-            const string expectedContent = "{\"extraCredits\":1,\"discountPercentage\":2}";
+            const string expectedContent = "{\"idPromotion\":3,\"extraCredits\":1,\"discountPercentage\":2}";
             var promoCodeRepositoryMock = new Mock<IPromotionRepository>();
             promoCodeRepositoryMock.Setup(x => x.GetPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
                 .ReturnsAsync(new Promotion
                 {
                     ExtraCredits = 1,
-                    DiscountPercentage = 2
+                    DiscountPercentage = 2,
+                    IdPromotion = 3
                 });
 
             var client = _factory.WithWebHostBuilder(builder =>

--- a/Doppler.AccountPlans/Model/Promotion.cs
+++ b/Doppler.AccountPlans/Model/Promotion.cs
@@ -2,6 +2,7 @@ namespace Doppler.AccountPlans.Model
 {
     public class Promotion
     {
+        public int IdPromotion { get; set; }
         public int? ExtraCredits { get; set; }
         public int? DiscountPercentage { get; set; }
     }


### PR DESCRIPTION
# Background
We need to add idPromotion property because the Billing user API needs this value to create agreement flow