### PR TITLE
fix: do not open connection on factory

### DIFF
--- a/Doppler.AccountPlans.Test/Utils/ServiceCollectionExtensions.cs
+++ b/Doppler.AccountPlans.Test/Utils/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Doppler.AccountPlans.Test.Utils
         public static void SetupConnectionFactory(this IServiceCollection services, DbConnection dbConnection)
         {
             var mockDatabaseConnectionFactory = new Mock<IDatabaseConnectionFactory>();
-            mockDatabaseConnectionFactory.Setup(a => a.GetConnection()).ReturnsAsync(dbConnection);
+            mockDatabaseConnectionFactory.Setup(a => a.GetConnection()).Returns(dbConnection);
             services.AddSingleton(mockDatabaseConnectionFactory.Object);
         }
     }

--- a/Doppler.AccountPlans/Infrastructure/AccountPlansRepository.cs
+++ b/Doppler.AccountPlans/Infrastructure/AccountPlansRepository.cs
@@ -17,7 +17,7 @@ namespace Doppler.AccountPlans.Infrastructure
 
         public async Task<IEnumerable<PlanDiscountInformation>> GetPlanDiscountInformation(int planId, string paymentMethod)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var result = await connection.QueryAsync<PlanDiscountInformation>(@"
 SELECT
     DP.[IdDiscountPlan],
@@ -37,7 +37,7 @@ ORDER BY
 
         public async Task<PlanInformation> GetPlanInformation(int planId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var result = await connection.QueryAsync<PlanInformation>(@"
 SELECT
     UTP.[IdUserType],
@@ -56,7 +56,7 @@ WHERE
 
         public async Task<PlanInformation> GetCurrentPlanInformation(string accountName)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var currentPlan = await connection.QueryFirstOrDefaultAsync<PlanInformation>(@"
 SELECT
@@ -78,7 +78,7 @@ WHERE
 
         public async Task<PlanDiscountInformation> GetDiscountInformation(int discountId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var discountPlan = await connection.QueryFirstOrDefaultAsync<PlanDiscountInformation>(@"
 SELECT

--- a/Doppler.AccountPlans/Infrastructure/DatabaseConnectionFactory.cs
+++ b/Doppler.AccountPlans/Infrastructure/DatabaseConnectionFactory.cs
@@ -14,15 +14,6 @@ namespace Doppler.AccountPlans.Infrastructure
             _connectionString = dopplerDataBaseSettings.Value.GetSqlConnectionString();
         }
 
-        /// <summary>
-        /// Open new connection and return it for use
-        /// </summary>
-        /// <returns></returns>
-        public async Task<IDbConnection> GetConnection()
-        {
-            var cn = new SqlConnection(_connectionString);
-            await cn.OpenAsync();
-            return cn;
-        }
+        public IDbConnection GetConnection() => new SqlConnection(_connectionString);
     }
 }

--- a/Doppler.AccountPlans/Infrastructure/IDatabaseConnectionFactory.cs
+++ b/Doppler.AccountPlans/Infrastructure/IDatabaseConnectionFactory.cs
@@ -5,6 +5,6 @@ namespace Doppler.AccountPlans.Infrastructure
 {
     public interface IDatabaseConnectionFactory
     {
-        Task<IDbConnection> GetConnection();
+        IDbConnection GetConnection();
     }
 }

--- a/Doppler.AccountPlans/Infrastructure/PromotionRepository.cs
+++ b/Doppler.AccountPlans/Infrastructure/PromotionRepository.cs
@@ -17,7 +17,7 @@ namespace Doppler.AccountPlans.Infrastructure
 
         public async Task<Promotion> GetPromotionByCode(string code, int planId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var userType = await GetUserTypeByPlan(planId);
 
@@ -66,7 +66,7 @@ WHERE
 
         private async Task<int> GetUserTypeByPlan(int planId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var userPlanTypeId = await connection.QueryFirstOrDefaultAsync<int>(@"
 SELECT


### PR DESCRIPTION
It is not necessary to open the connection explicitly, dapper will do it when a query is executed.
Based in fix (https://github.com/FromDoppler/doppler-html-editor-api/pull/42)